### PR TITLE
fix: [docs] typo error to run docker-compose

### DIFF
--- a/docs/oss/deploy-poozle.mdx
+++ b/docs/oss/deploy-poozle.mdx
@@ -10,7 +10,7 @@ description: "Deploying Poozle Open-Source just takes 1 minute."
 ```bash
 git clone https://github.com/poozlehq/engine.git
 cd engine
-docker compose up -d
+docker-compose up -d
 ```
 
 3. Create user using the following commands


### PR DESCRIPTION
This PR fixes #141 

Fixing the typo for user to run the project with `docker-compose`